### PR TITLE
Change `editorSuggestWidget.selectedBackground` to #54bef240

### DIFF
--- a/themes/starfall-color-theme-darker.json
+++ b/themes/starfall-color-theme-darker.json
@@ -94,7 +94,7 @@
     "editorSuggestWidget.focusHighlightForeground": "#54bef2",
     "editorSuggestWidget.foreground": "#d2d8e7",
     "editorSuggestWidget.highlightForeground": "#54bef2",
-    "editorSuggestWidget.selectedBackground": "#212127",
+    "editorSuggestWidget.selectedBackground": "#54bef240",
     "editorSuggestWidget.selectedForeground": "#cacde2",
     "editorWarning.foreground": "#ffcb6b80",
     "editorWhitespace.foreground": "#cacde240",

--- a/themes/starfall-color-theme-ocean.json
+++ b/themes/starfall-color-theme-ocean.json
@@ -94,7 +94,7 @@
     "editorSuggestWidget.focusHighlightForeground": "#54bef2",
     "editorSuggestWidget.foreground": "#d2d8e7",
     "editorSuggestWidget.highlightForeground": "#54bef2",
-    "editorSuggestWidget.selectedBackground": "#0e131b",
+    "editorSuggestWidget.selectedBackground": "#54bef240",
     "editorSuggestWidget.selectedForeground": "#cacde2",
     "editorWarning.foreground": "#ffcb6b80",
     "editorWhitespace.foreground": "#cacde240",

--- a/themes/starfall-color-theme-palenight.json
+++ b/themes/starfall-color-theme-palenight.json
@@ -94,7 +94,7 @@
     "editorSuggestWidget.focusHighlightForeground": "#54bef2",
     "editorSuggestWidget.foreground": "#d2d8e7",
     "editorSuggestWidget.highlightForeground": "#54bef2",
-    "editorSuggestWidget.selectedBackground": "#202337",
+    "editorSuggestWidget.selectedBackground": "#54bef240",
     "editorSuggestWidget.selectedForeground": "#cacde2",
     "editorWarning.foreground": "#ffcb6b80",
     "editorWhitespace.foreground": "#cacde240",

--- a/themes/starfall-color-theme.json
+++ b/themes/starfall-color-theme.json
@@ -94,7 +94,7 @@
     "editorSuggestWidget.focusHighlightForeground": "#54bef2",
     "editorSuggestWidget.foreground": "#d2d8e7",
     "editorSuggestWidget.highlightForeground": "#54bef2",
-    "editorSuggestWidget.selectedBackground": "#1b2636",
+    "editorSuggestWidget.selectedBackground": "#54bef240",
     "editorSuggestWidget.selectedForeground": "#cacde2",
     "editorWarning.foreground": "#ffcb6b80",
     "editorWhitespace.foreground": "#cacde240",


### PR DESCRIPTION
## ☄️ Pull Request

<!-- Fill the following checklist. -->
- [x] Used a clear / meaningful title for this pull request.
- [x] Tested the changes in your own code (on your projects).
- [x] Added / Edited tests to reflect changes (`test` folder).
- [x] Have read the **Contributing** part of the **README**.
- [ ] Passed `npm test`.
- [x] I noted my changes in the pull request body and/or changelog.

<!-- Complete the following parts. -->

#### 🌌 Fixes

<!-- List the issues that this fixes. -->
Resolves #48.

#### Description

<!-- A clear & concise explanation of the pull and why it was opened. -->
Add line background to selected line in editor suggestion widget.

#### What changes have you made?

- changed value of `editorSuggestWidget.selectedBackground` to `#54bef240`

#### What tests have you completed?

- [x] Tested this in Visual Studio Code v1.65.2.
- [x] Tested this in Visual Studio Code Insiders v1.66.0.
- [x] Tested this in GitHub Codespaces v1.65.2.
- [x] Tested this in VSCodium v1.65.2.
